### PR TITLE
Documentation update

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,26 +15,22 @@ description: |-
 ```terraform
 # connect to Microsoft SQL Server
 provider "sql" {
-  alias = "mssql"
   url   = "sqlserver://sa:password@localhost:1433"
 }
 
 # connect to PostgreSQL
 provider "sql" {
-  alias = "postgres"
   url   = "postgres://postgres:password@localhost:5432/mydatabase?sslmode=disable"
 }
 
 # connect to CockroachDB
 provider "sql" {
-  alias = "cockroach"
   # use the postgres driver for CockroachDB
   url = "postgres://root@localhost:26257/events?sslmode=disable"
 }
 
 # connect to a MySQL server
 provider "sql" {
-  alias = "mysql"
   url   = "mysql://root:password@tcp(localhost:3306)/mysql"
 }
 ```

--- a/docs/resources/migrate.md
+++ b/docs/resources/migrate.md
@@ -15,6 +15,7 @@ description: |-
 ```terraform
 resource "sql_migrate" "db" {
   migration {
+    id = "db_init_schema"
     up = <<SQL
 CREATE TABLE users (
 	user_id integer unique,
@@ -27,6 +28,7 @@ SQL
   }
 
   migration {
+    id = "db_seed_data"
     up   = "INSERT INTO users VALUES (1, 'Paul Tyng', 'paul@example.com');"
     down = "DELETE FROM users WHERE user_id = 1;"
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,24 +1,20 @@
 # connect to Microsoft SQL Server
 provider "sql" {
-  alias = "mssql"
   url   = "sqlserver://sa:password@localhost:1433"
 }
 
 # connect to PostgreSQL
 provider "sql" {
-  alias = "postgres"
   url   = "postgres://postgres:password@localhost:5432/mydatabase?sslmode=disable"
 }
 
 # connect to CockroachDB
 provider "sql" {
-  alias = "cockroach"
   # use the postgres driver for CockroachDB
   url = "postgres://root@localhost:26257/events?sslmode=disable"
 }
 
 # connect to a MySQL server
 provider "sql" {
-  alias = "mysql"
   url   = "mysql://root:password@tcp(localhost:3306)/mysql"
 }

--- a/examples/resources/sql_migrate/resource.tf
+++ b/examples/resources/sql_migrate/resource.tf
@@ -1,5 +1,6 @@
 resource "sql_migrate" "db" {
   migration {
+    id = "db_init_schema"
     up = <<SQL
 CREATE TABLE users (
 	user_id integer unique,
@@ -12,6 +13,7 @@ SQL
   }
 
   migration {
+    id = "db_seed_data"
     up   = "INSERT INTO users VALUES (1, 'Paul Tyng', 'paul@example.com');"
     down = "DELETE FROM users WHERE user_id = 1;"
   }


### PR DESCRIPTION
* added the required `id` argument in examples of `migration` blocks
* removing unnecessary `alias` argument in the `provider "sql"` block