### PR TITLE
Fix missing `id` in migration example

### DIFF
--- a/examples/resources/sql_migrate/resource.tf
+++ b/examples/resources/sql_migrate/resource.tf
@@ -1,5 +1,6 @@
 resource "sql_migrate" "db" {
   migration {
+    id = "create-users-table"
     up = <<SQL
 CREATE TABLE users (
 	user_id integer unique,
@@ -12,6 +13,7 @@ SQL
   }
 
   migration {
+    id   = "insert-users"
     up   = "INSERT INTO users VALUES (1, 'Paul Tyng', 'paul@example.com');"
     down = "DELETE FROM users WHERE user_id = 1;"
   }


### PR DESCRIPTION
The migration example does not include an id in the migration blocks but the id is required.