### PR TITLE
Added disabled option on the provider to prevent the provider from trying to connect to resources that have not been provisioned

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,4 +51,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -22,3 +22,10 @@ provider "sql" {
   alias = "mysql"
   url   = "mysql://root:password@tcp(localhost:3306)/mysql"
 }
+
+# mark the provider as disabled so that it will not try to connect
+provider "sql" {
+  alias    = "postgres"
+  url      = "postgres://postgres:password@localhost:5432/mydatabase?sslmode=disable"
+  disabled = true
+}

--- a/internal/provider/resource_migrate_disabled_test.go
+++ b/internal/provider/resource_migrate_disabled_test.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	helperresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestResourceNullMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long test")
+	}
+
+	for _, server := range testServers {
+		t.Run(server.ServerType, func(t *testing.T) {
+			url, _, err := server.URL()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			helperresource.UnitTest(t, helperresource.TestCase{
+				ProtoV6ProviderFactories: protoV6ProviderFactories,
+				Steps: []helperresource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+provider "sql" {
+	url 	 = null # %q
+	disabled = true
+
+	max_idle_conns = 0
+}
+
+resource "sql_migrate" "db" {
+	count = 0
+
+	migration {
+		id = "create table"
+
+		up = <<SQL
+CREATE TABLE inline_migrate_test (
+	user_id integer unique,
+	name    varchar(40),
+	email   varchar(40)
+);
+SQL
+
+		down = <<SQL
+DROP TABLE inline_migrate_test;
+SQL
+	}
+}
+
+data "sql_query" "users" {
+	count 	   = 0
+	depends_on = [sql_migrate.db]
+
+	query = "select * from inline_migrate_test"
+}
+
+output "rowcount" {
+	value = length(data.sql_query.users)
+}
+				`, url),
+						Check: helperresource.ComposeTestCheckFunc(
+							helperresource.TestCheckOutput("rowcount", "0"),
+						),
+					},
+					{
+						Config: fmt.Sprintf(`
+provider "sql" {
+	url      = null # %q
+	disabled = true
+
+	max_idle_conns = 0
+}
+
+resource "sql_migrate" "db" {
+	count = 0
+
+	migration {
+		id = "create table"
+
+		up = <<SQL
+CREATE TABLE inline_migrate_test (
+	user_id integer unique,
+	name    varchar(40),
+	email   varchar(40)
+);
+SQL
+
+		down = <<SQL
+DROP TABLE inline_migrate_test;
+SQL
+	}
+
+	migration {
+		id   = "insert row"
+		up   = "INSERT INTO inline_migrate_test VALUES (1, 'Paul Tyng', 'paul@example.com');"
+		down = "DELETE FROM inline_migrate_test WHERE user_id = 1;"
+	}
+}
+
+data "sql_query" "users" {
+	count 	   = 0
+	depends_on = [sql_migrate.db]
+
+	query = "select * from inline_migrate_test"
+}
+
+output "rowcount" {
+	value = length(data.sql_query.users)
+}
+				`, url),
+						Check: helperresource.ComposeTestCheckFunc(
+							helperresource.TestCheckOutput("rowcount", "0"),
+						),
+					},
+				},
+			})
+		})
+	}
+}


### PR DESCRIPTION
Can now set the following on the provider configuration to prevent loading

``` yaml
# mark the provider as disabled so that it will not try to connect
provider "sql" {
  alias    = "postgres"
  url      = "postgres://postgres:password@localhost:5432/mydatabase?sslmode=disable"
  disabled = true
}
```
